### PR TITLE
Documentation: Add documentation for `Profile.php` #4

### DIFF
--- a/src/Data/Profile.php
+++ b/src/Data/Profile.php
@@ -99,10 +99,11 @@ class Profile
     }
 
     /**
+     * Gets the profile picture of a specific user it will be returned as base64 string
      * @param false $refetch
-     * @return mixed
+     * @return string
      */
-    public function getProfilePict_base64($refetch = false)
+    public function getProfilePict_base64($refetch = false) : string
     {
         if ($this->fetched_data && !$refetch) {
             return $this->fetched_data;
@@ -118,6 +119,7 @@ class Profile
     }
 
     /**
+     * Returns personal information of the used profile.
      * @param false $refetch
      * @return array
      */
@@ -202,6 +204,7 @@ class Profile
     }
 
     /**
+     * Fetches data from the profile API Endpoint
      * @return void
      */
     protected function fetch()

--- a/src/Data/Profile.php
+++ b/src/Data/Profile.php
@@ -98,6 +98,10 @@ class Profile
         $this->fetch();
     }
 
+    /**
+     * @param false $refetch
+     * @return mixed
+     */
     public function getProfilePict_base64($refetch = false)
     {
         if ($this->fetched_data && !$refetch) {
@@ -113,7 +117,11 @@ class Profile
         return $matched_pict[2][0];
     }
 
-    public function getDatas($refetch = false)
+    /**
+     * @param false $refetch
+     * @return array
+     */
+    public function getDatas($refetch = false) : array
     {
         if ($this->fetched_data && !$refetch) {
             return $this->fetched_data;
@@ -193,6 +201,9 @@ class Profile
         return $datas;
     }
 
+    /**
+     * @return void
+     */
     protected function fetch()
     {
 


### PR DESCRIPTION
In order to get the correct return type for the getProfilePict_base64(), there is a need of refactoring, since the data type is not 100% clear.
I added it as mixed data.